### PR TITLE
make the 'More' button work on mobile

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,5 +1,4 @@
 $(document).ready(function(){
-	
 
 	// MENU OVERLAY
 
@@ -47,24 +46,24 @@ $(document).ready(function(){
 
 */
 
-  $(".event").each(function(){
-    
-    var event = $(this);
-    event.find(".long").hide();
-    
-    event.find(".more-button").click(function(){
-      
-      event.find(".long").slideToggle();
-      
-    })   
-    
-  })
-
 	  var s = skrollr.init({
 			forceHeight: false
 		});
 
 	}
+
+  $(".event").each(function(){
+    
+    var event = $(this);
+    event.find(".long").hide();
+    
+    event.find(".more-button").on('click', function(){
+
+      event.find(".long").slideToggle();
+      
+    })   
+    
+  })
 
 
   $(".agenda .event .long").hide();


### PR DESCRIPTION
The details get crammed into a tiny column, but you can read them.

I sort of wonder if these things were deliberately turned off for mobile for some reason that didn't occur to me, but I'm assuming that if the buttons weren't wanted on mobile they would be hidden rather than being there and broken.
